### PR TITLE
Refactor context handling

### DIFF
--- a/src/Comment.php
+++ b/src/Comment.php
@@ -15,8 +15,8 @@ namespace Yannoff\Component\YAML;
  *
  * @method string  getComment()
  * @method Comment setComment(string $comment)
- * @method Ypath   getContext()
- * @method Comment setContext(Ypath $ypath)
+ * @method DataLine getContextLine()
+ * @method Comment  setContextLine(DataLine $line)
  * @method string  getType()
  * @method Comment setType(string $type)
  */
@@ -43,11 +43,11 @@ class Comment extends DataLine
     protected $comment;
 
     /**
-     * The comment context: YPath to the sibling (for full-line comments) or current line (for inline comments)
+     * The comment context: sibling (for full-line comments) or current Line (for inline comments)
      *
-     * @var YPath
+     * @var DataLine
      */
-    protected $context;
+    protected $contextLine;
 
     /**
      * The comment line type (inline/full/empty)
@@ -77,7 +77,8 @@ class Comment extends DataLine
 
 
         if (empty($data)) {
-            $this->setType(self::TYPE_COMMENT_FULL);
+            $type = preg_match('/^\s*$/', $raw) ? self::TYPE_COMMENT_EMPTY : self::TYPE_COMMENT_FULL;
+            $this->setType($type);
             return;
         }
 

--- a/src/DataLine.php
+++ b/src/DataLine.php
@@ -102,10 +102,20 @@ class DataLine extends Line
      */
     public function getIndent()
     {
-        $regexp = sprintf('/^((%s)*)[a-zA-z\-#]/', self::TAB);
+        $regexp = sprintf('/^((%s)*)([a-zA-z\-#]*)/', self::TAB);
         preg_match($regexp, $this->raw, $tabs);
         $indent = substr_count($tabs[0], self::TAB);
         return $indent;
+    }
+
+    /**
+     * Return true if the line is an instance of Comment
+     *
+     * @return bool
+     */
+    public function isComment()
+    {
+        return ($this instanceof Comment);
     }
 
     /**


### PR DESCRIPTION
Closes #2 

- Discriminate `TYPE_COMMENT_EMPTY` from other comment types
- Use `DataLine` objects for comment context instead of `YPath`
- `Contents::getLine()` now return either `Comment` or `DataLine`
- Adapt `injectComments` & `collectComments` to the new system